### PR TITLE
Forwarded select Rectangle kwargs to the Conneciton patch

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -474,11 +474,22 @@ class Axes(_AxesBase):
                 if self.yaxis.get_inverted():
                     ey = 1 - ey
                 xy_data = x + ex * width, y + ey * height
+
+                blacklist = {
+                    'alpha', 'rasterized', 'transform',
+                    'color', 'facecolor', 'url',
+                    'hatch', 'in_layout', 'path_effects'}
+
+                patch_kwargs = {
+                    key: val for key, val in kwargs.items()
+                    if key not in blacklist}
+
                 p = mpatches.ConnectionPatch(
                     xyA=xy_inset_ax, coordsA=inset_ax.transAxes,
                     xyB=xy_data, coordsB=self.transData,
                     arrowstyle="-", zorder=zorder,
-                    edgecolor=edgecolor, alpha=alpha)
+                    edgecolor=edgecolor, alpha=alpha,
+                    **patch_kwargs)
                 connects.append(p)
                 self.add_patch(p)
 


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
